### PR TITLE
Updated piston-window dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 plotters-backend = "0.3.0"
-piston_window = "0.112.0"
+piston_window = "0.117.0"
 
 [dev-dependencies]
 plotters = {version = "0.3.0", default_features = false, features = ["ttf", "all_series"]}


### PR DESCRIPTION
There seems to be a bug with `piston_window` and its default `glutin` backend in version `0.112.0` that can cause a panic when displaying a window in the latest versions of rust. This is fixed in later versions (it works for me from version `0.114.0`) of `piston_window`.