### PR TITLE
Updated piston_window to v0.120.0 so that it works with latest stable rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 plotters-backend = "0.3.0"
-piston_window = "0.112.0"
+piston_window = "0.120.0"
 
 [dev-dependencies]
 plotters = {version = "0.3.0", default_features = false, features = ["ttf", "all_series"]}


### PR DESCRIPTION
As stated in an older pull request, this allows the `plotters-piston` repo to now run with the latest stable rust.