### PR TITLE
Use window-framebuffer scale when drawing circles

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -161,7 +161,7 @@ impl<'a, 'b> DrawingBackend for PistonBackend<'a, 'b> {
         style: &S,
         fill: bool,
     ) -> Result<(), DrawingErrorKind<Self::ErrorType>> {
-        let rect = circle(center.0 as f64, center.1 as f64, radius as f64);
+        let rect = circle(center.0 as f64 * self.scale, center.1 as f64 * self.scale, radius as f64 * self.scale);
         if fill {
             ellipse(
                 make_piston_rgba(&style.color()),


### PR DESCRIPTION
`PistonBackend::draw_circle` fails to take into account `self.scale` when creating the rect to draw the circle into. This causes the position and size of the drawn circle to be off if the framebuffer size is not equal to the window size. 