### PR TITLE
Proposal to use git-master dependencies for collaboration, testing, and CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 piston_window = "0.120.0"
 
 [dependencies.plotters-backend]
-branch = "master"
 git = "https://github.com/plotters-rs/plotters-backend"
 # version = "0.3.1"
 
@@ -23,7 +22,6 @@ git = "https://github.com/plotters-rs/plotters-backend"
 systemstat = "0.1.5"
 
 [dev-dependencies.plotters]
-branch = "master"
 default_features = false
 features = ["ttf", "all_series"]
 git = "https://github.com/plotters-rs/plotters"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,19 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-plotters-backend = "0.3.0"
 piston_window = "0.120.0"
 
+[dependencies.plotters-backend]
+branch = "master"
+git = "https://github.com/plotters-rs/plotters-backend"
+# version = "0.3.1"
+
 [dev-dependencies]
-plotters = {version = "0.3.0", default_features = false, features = ["ttf", "all_series"]}
 systemstat = "0.1.5"
+
+[dev-dependencies.plotters]
+branch = "master"
+default_features = false
+features = ["ttf", "all_series"]
+git = "https://github.com/plotters-rs/plotters"
+# version = "0.3.1"

--- a/examples/cpustat.rs
+++ b/examples/cpustat.rs
@@ -1,6 +1,6 @@
 use piston_window::{EventLoop, PistonWindow, WindowSettings};
 use plotters::prelude::*;
-use plotters_piston::{draw_piston_window, PistonBackend};
+use plotters_piston::{draw_piston_window};
 use systemstat::platform::common::Platform;
 use systemstat::System;
 
@@ -43,7 +43,7 @@ fn main() {
             .caption("Real Time CPU Usage", ("sans-serif", 30))
             .x_label_area_size(40)
             .y_label_area_size(50)
-            .build_ranged(0..N_DATA_POINTS as u32, 0f32..1f32)?;
+            .build_cartesian_2d(0..N_DATA_POINTS as u32, 0f32..1f32)?;
 
         cc.configure_mesh()
             .x_label_formatter(&|x| format!("{}", -(LENGTH as f32) + (*x as f32 / FPS as f32)))


### PR DESCRIPTION
This proposal aims to improve collaboration, testing, and CI by altering the version of the `plotters-backend` and `plotters` dependencies in `Cargo.toml`. Instead of using the stable versions of those crates, the `git-master` versions are used.

Using the `git-master` versions of the `plotters-` crates is vital for pre-release quality assurance and frustration-free collaboration in Plotters. It also reduces surprises at release time.

This is part of the proposal discussed on plotters-rs/plotters#373